### PR TITLE
feat(livestream): fix live streaming components bug

### DIFF
--- a/examples/live.js
+++ b/examples/live.js
@@ -17,8 +17,8 @@ const createFFTask = () => {
   const cacheDir = path.join(__dirname, './cache/');
   const outputDir = path.join(__dirname, './output/');
 
-  const width = 700;
-  const height = 500;
+  const width = 1920;
+  const height = 1080;
   // create creator instance
   const creator = new FFCreator({
     cacheDir,
@@ -27,6 +27,7 @@ const createFFTask = () => {
     width,
     height,
     log: true,
+    preset: 'veryfast',
     pushLive: true,
     audio,
   });
@@ -39,8 +40,8 @@ const createFFTask = () => {
   fbg.setXY(50, 50);
   scene.addChild(fbg);
 
-  const fflive = new FFLive({ path: live, x: 100, y: 100 });
-  fflive.setScale(0.3);
+  const fflive = new FFLive({ path: live, x: 0, y: 0 });
+  fflive.setScale(1);
   fflive.addEffect('moveInRight', 2.5, 3.5);
   scene.addChild(fflive);
 

--- a/lib/conf/conf.js
+++ b/lib/conf/conf.js
@@ -25,6 +25,7 @@ class Conf {
     this.copyByDefaultVal(conf, 'queue', 2);
     this.copyByDefaultVal(conf, 'threads', 1);
     this.copyByDefaultVal(conf, 'preset', 'medium');
+    this.copyByDefaultVal(conf, 'vprofile', 'baseline');
     this.copyByDefaultVal(conf, 'debug', false);
     this.copyByDefaultVal(conf, 'audioLoop', true);
     this.copyByDefaultVal(conf, 'pushLive', false);

--- a/lib/utils/ffmpeg.js
+++ b/lib/utils/ffmpeg.js
@@ -76,12 +76,14 @@ const FFmpegUtil = {
     const vb = conf.getVal('vb');
     const crf = conf.getVal('crf');
     const preset = conf.getVal('preset');
+    const vprofile = conf.getVal('vprofile');
+    const pushLIve = conf.getVal('pushLive');
 
     let outputOptions = []
       //---- misc ----
       .concat([
-        '-map',
-        '0',
+        // '-map',
+        // '0',
         '-hide_banner', // hide_banner - parameter, you can display only meta information
         '-map_metadata',
         '-1',
@@ -94,7 +96,7 @@ const FFmpegUtil = {
         '-c:v',
         'libx264', // c:v - H.264
         '-profile:v',
-        'main', // profile:v - main profile: mainstream image quality. Provide I / P / B frames
+        vprofile, // profile:v - main profile: mainstream image quality. Provide I / P / B frames, default
         '-preset',
         preset, // preset - compromised encoding speed
         '-crf',
@@ -113,6 +115,11 @@ const FFmpegUtil = {
     //---- audio ----
     if (audio) {
       outputOptions = outputOptions.concat(['-c:a', 'copy', '-shortest']);
+    }
+
+    //---- live stream ----
+    if (!pushLIve) {
+      outputOptions = outputOptions.concat(['-map', '0']);
     }
 
     command.outputOptions(outputOptions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ffcreatorlite",
-  "version": "2.2.2",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
1. 修复 ffmpeg 的默认 '-map 0' 参数， 会生成两路 libx264  stream 流，导致 -f flv 推流到流媒体服务器报错失败 #12 
2. 新增 preset conf 配置，避免实时处理过程中的性能问题